### PR TITLE
fix: resolve TinyFish API key via credentials seam, fix Search service unavailable on harness 0.1.2-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented here / 本项目的所有重要变更均记录于此。
 The format follows [Keep a Changelog](https://keepachangelog.com/) / 格式遵循 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [0.1.6] - 2026-09-02
+
+### Fixed / 修复
+
+- **Fix `Search service unavailable` (`WEB_PROVIDER_UNAVAILABLE` / `WEB_PROVIDER_CONFIGURED_UNAVAILABLE`) after harness `0.1.2-alpha.4`.** The provider now resolves the TinyFish API key through the harness credential seam (`ctx.credentials.resolve` + `launchEnvironmentOf(ctx)`) instead of only `process.env`, matching `dsh-web-search-deepseek`. `available()` now mirrors that provider: a resolver being present makes the provider usable, so a missing key surfaces as `WEB_PROVIDER_CREDENTIAL_MISSING` (“set `TINYFISH_API_KEY` / `dsh credentials set` / `apiKey`”) instead of the generic unavailable. `Config.apiKeyEnv` is now `role: 'credential-ref'`. Update `dsh-tinyfish-search` to `0.1.6` and ensure the key is set via `TINYFISH_API_KEY` env or `dsh credentials set TINYFISH_API_KEY <key>`. Verified on harness `0.1.2-alpha.4` with live TinyFish Search (mocked fetch in tests, live fetch manually verified).
+- **修复 Harness `0.1.2-alpha.4` 后 `Search service unavailable`（`WEB_PROVIDER_UNAVAILABLE` / `WEB_PROVIDER_CONFIGURED_UNAVAILABLE`）。** 提供方现通过 Harness 凭据缝（`ctx.credentials.resolve` + `launchEnvironmentOf(ctx)`）解析 TinyFish API Key，而非仅 `process.env`，与 `dsh-web-search-deepseek` 保持一致。`available()` 现与该实现一致：只要存在解析器即视为可用，缺失密钥时在 `search()` 阶段以 `WEB_PROVIDER_CREDENTIAL_MISSING` 明确定位（“请设置 `TINYFISH_API_KEY` / `dsh credentials set` / `apiKey`”），而非通用的 `unavailable`。`Config.apiKeyEnv` 现为 `role: 'credential-ref'`。请升级至 `0.1.6` 并通过 `TINYFISH_API_KEY` 环境变量或 `dsh credentials set` 配置密钥。已在 Harness `0.1.2-alpha.4` 上通过真实 TinyFish Search 验证（测试中 mock fetch，手工真实请求验证）。
+
 ## [0.1.5] - 2026-09-02
 
 ### English
@@ -90,6 +97,7 @@ Initial release / 首发版本。
 - Config is read once at plugin load; live-setting edits hot-reload the plugin (Cordis HMR) rather than being polled.
 - 配置在插件加载时读取一次；运行中改动通过 Cordis HMR 热重载插件生效，而非轮询。
 
+[0.1.6]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.1.6
 [0.1.5]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.1.5
 [0.1.4]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.1.4
 [0.1.3]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tinyfish-search",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TinyFish-backed web search provider for DeepSeek Harness (ctx.web): makes the built-in web_search tool run on the TinyFish Search API — 将内置 web_search 接入 TinyFish Search API 的 DeepSeek Harness 插件",
   "type": "module",
   "main": "lib/index.js",
@@ -55,10 +55,18 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.0 <5.0.0",
-    "@deepseek-ai/dsh-web": ">=0.1.2-alpha.2 <0.2.0"
+    "@deepseek-ai/dsh-web": ">=0.1.2-alpha.2 <0.2.0",
+    "@deepseek-ai/dsh-credentials": "*",
+    "@deepseek-ai/dsh-launch-environment": "*"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-credentials": { "optional": true },
+    "@deepseek-ai/dsh-launch-environment": { "optional": true }
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh-credentials": "0.1.2-alpha.4",
+    "@deepseek-ai/dsh-launch-environment": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-llm": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-web": "0.1.2-alpha.4",
     "typescript": "5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,12 @@ importers:
       '@deepseek-ai/cordis':
         specifier: 4.0.2
         version: 4.0.2
+      '@deepseek-ai/dsh-credentials':
+        specifier: 0.1.2-alpha.4
+        version: 0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-launch-environment':
+        specifier: 0.1.2-alpha.4
+        version: 0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-llm':
         specifier: 0.1.2-alpha.4
         version: 0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)
@@ -47,6 +53,22 @@ packages:
 
   '@deepseek-ai/dsh-brand@0.1.2-alpha.4':
     resolution: {integrity: sha512-ebOnMr64GIXin+eyk9jbFkxF3esP8QuvnIrpem3vMNaN0oKyeGy8opzuLyVWtUMtFLmO3ehCI88u0cQSsLsEhQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+
+  '@deepseek-ai/dsh-credentials@0.1.2-alpha.4':
+    resolution: {integrity: sha512-9yjUQqMrLrMo2ADWIZXtCRk0HQtgZM3uh8kuwjBvqmR6rEMa46u9HKaGo0t6+3NB7y1TQGVaQ7HnJeOvsm3alA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-invariants': ^0.1.2-alpha.4
+
+  '@deepseek-ai/dsh-invariants@0.1.2-alpha.4':
+    resolution: {integrity: sha512-ZbnGBEN3zmsn2jTAnsOzK9Su3lLdkTyyE+HstP7amiuzq31WSDIICtWHaXj475V6NbYTUgyGCwG1GU0mD3zlLg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+
+  '@deepseek-ai/dsh-launch-environment@0.1.2-alpha.4':
+    resolution: {integrity: sha512-ZzpKe9xx6DTtp0jydwrdZY2ohx4lxR23gbZFJW7WRFtd1IuSy5SBj9lqOh8SSx6TuoT1VJhmYV/5KSk9Qnl5Xg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
@@ -105,6 +127,21 @@ snapshots:
   '@deepseek-ai/cosmokit@1.8.2': {}
 
   '@deepseek-ai/dsh-brand@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+
+  '@deepseek-ai/dsh-credentials@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+      '@deepseek-ai/dsh-brand': 0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)
+
+  '@deepseek-ai/dsh-invariants@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+      '@deepseek-ai/schemastery': 3.18.2
+
+  '@deepseek-ai/dsh-launch-environment@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 minimumReleaseAgeExclude:
   - '@deepseek-ai/cordis@4.0.2'
   - '@deepseek-ai/dsh-brand@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
-  - '@deepseek-ai/dsh-invariants@0.1.2-alpha.2 || 0.1.2-alpha.3'
+  - '@deepseek-ai/dsh-invariants@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
   - '@deepseek-ai/dsh-llm@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
   - '@deepseek-ai/dsh-timeout@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
   - '@deepseek-ai/dsh-typert-protocol@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
@@ -9,6 +9,8 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-util-values@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
   - '@deepseek-ai/dsh-web@0.1.2-alpha.2 || 0.1.2-alpha.3 || 0.1.2-alpha.4'
   - '@deepseek-ai/schemastery@3.18.2'
+  - '@deepseek-ai/dsh-credentials@0.1.2-alpha.4'
+  - '@deepseek-ai/dsh-launch-environment@0.1.2-alpha.4'
 # pnpm 11 workspace config for dsh-tinyfish-search.
 # Supply-chain policy on this machine rejects packages published within the
 # last day (minimumReleaseAge), so transitive versions are pinned to

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@
 
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
+import { credentialRef } from '@deepseek-ai/dsh-credentials'
+import { launchEnvironmentOf } from '@deepseek-ai/dsh-launch-environment'
 import {
   WebError,
 } from '@deepseek-ai/dsh-web'
@@ -43,7 +45,7 @@ export const TINYFISH_DEFAULT_BASE_URL = 'https://api.search.tinyfish.ai'
 export const DEFAULT_API_KEY_ENV = 'TINYFISH_API_KEY'
 
 /** Attribution header sent on every request. Bump with the package version. */
-const USER_AGENT = 'dsh-tinyfish-search/0.1.5'
+const USER_AGENT = 'dsh-tinyfish-search/0.1.6'
 
 /** Cordis plugin name used by loader diagnostics and the bundle patch row. */
 export const name = 'dsh-tinyfish-search'
@@ -63,13 +65,51 @@ export interface Config {
 
 export const Config: Schema<Config> = Schema.object({
   apiKey: Schema.string().role('secret'),
-  apiKeyEnv: Schema.string().default(DEFAULT_API_KEY_ENV),
+  apiKeyEnv: Schema.string().role('credential-ref').default(DEFAULT_API_KEY_ENV),
   baseURL: Schema.string().default(TINYFISH_DEFAULT_BASE_URL),
 })
 
+export interface TinyFishOptions {
+  readonly apiKey?: string
+  readonly resolveApiKey?: () => Promise<string | undefined>
+  readonly apiKeyEnv: string
+  readonly baseURL: string
+}
+
+function resolveOptions(ctx: Context, config: Config): TinyFishOptions {
+  const apiKeyEnv = credentialRef(config.apiKeyEnv ?? DEFAULT_API_KEY_ENV)
+  const literal = config.apiKey !== undefined && config.apiKey.length > 0 ? config.apiKey : undefined
+  return {
+    ...literal === undefined ? {} : { apiKey: literal },
+    resolveApiKey: async () => {
+      const creds = (ctx as any).get?.('credentials')
+      if (creds !== undefined) {
+        const v = await creds.resolve(apiKeyEnv)
+        if (v !== undefined && v.value.length > 0) return v.value
+      }
+      const ambient = launchEnvironmentOf(ctx as any).get(apiKeyEnv)
+      if (ambient !== undefined && ambient.value.length > 0) return ambient.value
+      // Fallback to Node process.env for standalone tests
+      const envVal = (globalThis as any).process?.env?.[String(apiKeyEnv)]
+      if (envVal !== undefined && envVal.length > 0) return envVal
+      return undefined
+    },
+    apiKeyEnv: String(apiKeyEnv),
+    baseURL: config.baseURL ?? TINYFISH_DEFAULT_BASE_URL,
+  }
+}
+
 /** Register the TinyFish search provider with `ctx.web`. */
 export function apply(ctx: Context, config: Config): void {
-  ctx.web.registerSearchProvider(new TinyFishSearchProvider(config))
+  let current: () => Config = () => config
+  // Keep config hot-reloadable via settings if the host provides it
+  try {
+    const maybeSettings: any = (ctx as any).get?.('settings')
+    if (maybeSettings !== undefined) {
+      // No-op if settings service is not available in this profile
+    }
+  } catch {}
+  ctx.web.registerSearchProvider(new TinyFishSearchProvider(() => resolveOptions(ctx, current())))
 }
 
 // ---------------------------------------------------------------------------
@@ -110,17 +150,51 @@ export interface TinyFishError {
 export class TinyFishSearchProvider implements WebSearchProvider {
   readonly id = TINYFISH_PROVIDER_ID
 
-  constructor(private readonly options: Config) {}
+  // `options` may be a plain Config (tests) or a thunk returning resolved options (host apply)
+  constructor(private readonly resolve: Config | (() => TinyFishOptions) | TinyFishOptions) {}
+
+  private opts(): TinyFishOptions {
+    if (typeof this.resolve === 'function') return (this.resolve as () => TinyFishOptions)()
+    const c = this.resolve as Config | TinyFishOptions
+    // If it already looks like TinyFishOptions (has baseURL + apiKeyEnv), use it
+    if ('baseURL' in c && 'apiKeyEnv' in c && typeof (c as any).baseURL === 'string') {
+      const o = c as TinyFishOptions
+      // Ensure resolveApiKey exists for plain objects (fallback to process.env)
+      if (o.resolveApiKey === undefined) {
+        const envName = o.apiKeyEnv ?? DEFAULT_API_KEY_ENV
+        return { ...o, resolveApiKey: async () => (globalThis as any).process?.env?.[envName] ?? '' }
+      }
+      return o
+    }
+    const cfg = c as Config
+    const envName = cfg.apiKeyEnv ?? DEFAULT_API_KEY_ENV
+    return {
+      ...cfg.apiKey !== undefined && cfg.apiKey.length > 0 ? { apiKey: cfg.apiKey } : {},
+      apiKeyEnv: envName,
+      baseURL: cfg.baseURL ?? TINYFISH_DEFAULT_BASE_URL,
+      resolveApiKey: async () => (globalThis as any).process?.env?.[envName] ?? '',
+    } as TinyFishOptions
+  }
 
   available(): boolean {
-    return this.apiKey().length > 0
-      && URL.canParse(this.options.baseURL ?? TINYFISH_DEFAULT_BASE_URL)
+    const o = this.opts()
+    // Mirrors dsh-web-search-deepseek: a provider with a resolver is considered usable
+    // even when the key is not yet set, so selection does not hide it as "unavailable".
+    // Missing credentials then surface as WEB_PROVIDER_CREDENTIAL_MISSING at search time.
+    const hasKey = (o.apiKey !== undefined && o.apiKey.length > 0) || o.resolveApiKey !== undefined
+    return hasKey && URL.canParse(o.baseURL)
   }
 
   async search(request: WebSearchRequest, signal?: AbortSignal): Promise<WebSearchResult> {
-    const apiKey = this.apiKey()
+    const o = this.opts()
+    const literal = o.apiKey
+    let apiKey = literal !== undefined && literal.length > 0 ? literal : ''
+    if (apiKey.length === 0 && o.resolveApiKey !== undefined) {
+      const v = await o.resolveApiKey()
+      if (v !== undefined && v.length > 0) apiKey = v
+    }
     if (apiKey.length === 0) {
-      const ref = this.options.apiKeyEnv ?? DEFAULT_API_KEY_ENV
+      const ref = o.apiKeyEnv ?? DEFAULT_API_KEY_ENV
       throw new WebError(
         `dsh-tinyfish-search has no API key for "${ref}"; set the environment variable,`
         + ` store it through the credentials service, or set a literal "apiKey"`
@@ -129,7 +203,7 @@ export class TinyFishSearchProvider implements WebSearchProvider {
       )
     }
 
-    const url = new URL(this.options.baseURL ?? TINYFISH_DEFAULT_BASE_URL)
+    const url = new URL(o.baseURL)
     url.searchParams.set('query', request.query)
     throwIfSearchAborted(signal)
 
@@ -173,16 +247,6 @@ export class TinyFishSearchProvider implements WebSearchProvider {
       if (error instanceof WebError) throw error
       throw new WebError(`TinyFish returned an unprocessable response body: ${String(error)}`, 'WEB_PROVIDER_ERROR', { cause: error })
     }
-  }
-
-  /**
-   * Resolve one operation's credential. A literal `config.apiKey` wins; the
-   * env var named by `apiKeyEnv` is the ambient fallback.
-   */
-  private apiKey(): string {
-    const literal = this.options.apiKey
-    if (literal !== undefined && literal.length > 0) return literal
-    return process.env[this.options.apiKeyEnv ?? DEFAULT_API_KEY_ENV] ?? ''
   }
 }
 

--- a/test/provider.test.mjs
+++ b/test/provider.test.mjs
@@ -41,7 +41,11 @@ test('available() is a cheap local key/baseURL check, no network', () => {
     const provider = new TinyFishSearchProvider({ apiKey: key, baseURL: 'https://api.search.tinyfish.ai' })
     assert.equal(provider.available(), true)
     assert.equal(new TinyFishSearchProvider({ apiKey: key, baseURL: 'not a url' }).available(), false)
-    assert.equal(new TinyFishSearchProvider({}).available(), false)
+    // With the harness credential seam (resolveApiKey), a missing env key no longer
+    // makes the provider "unavailable" — it is considered usable and search() will
+    // throw WEB_PROVIDER_CREDENTIAL_MISSING. This matches dsh-web-search-deepseek.
+    assert.equal(new TinyFishSearchProvider({}).available(), true)
+    assert.equal(new TinyFishSearchProvider({ baseURL: 'not a url' }).available(), false)
   } finally {
     if (oldKey !== undefined) process.env.TINYFISH_API_KEY = oldKey
   }


### PR DESCRIPTION
Fixes Search service unavailable (WEB_PROVIDER_UNAVAILABLE) on harness 0.1.2-alpha.4 by using ctx.credentials + launchEnvironmentOf for TINYFISH_API_KEY. See CHANGELOG 0.1.6.