### PR TITLE
release: v0.1.9 — fix missing tool-web re-enable in bundle patch; settings hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented here / 本项目的所有重要变更均记录于此。
 The format follows [Keep a Changelog](https://keepachangelog.com/) / 格式遵循 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [0.1.9] - 2026-09-03
+
+### Fixed / 修复
+
+- **Fix: the bundle patch now re-enables `tool-web` — without it `web_search` was never registered.** The `@deepseek-ai/dsh-web-app` bundle ships the `tool-web` row **disabled**; dsh-base enables it only in headless/server profiles. The searxng-web bundle re-enables the row in its own patch, but the dsh-tinyfish-search patch did not, so on a clean install into a web profile the model saw no `web_search` tool at all and the TinyFish provider sat idle (devices that appeared to work had a manual `tool-web` override in their profile patch from earlier debugging). The patch now restates the row with `search: true`, `fetch: true`, and the base timeouts, mirroring searxng-web. / **修复：bundle 补丁现重新启用 `tool-web` —— 缺失时 `web_search` 根本不会注册。** `@deepseek-ai/dsh-web-app` bundle 自带 `tool-web` **禁用**行（dsh-base 仅在 headless/server 组合中启用它）。searxng-web 的补丁自己重新启用了该行，而 dsh-tinyfish-search 的补丁没有 —— 干净安装到 web profile 后模型看不到 `web_search` 工具，TinyFish 提供方完全闲置（此前"能用"的设备是因为排障时在 profile 补丁里手工加了 `tool-web` 覆盖行）。现按 searxng-web 的方式补上该行（`search: true`、`fetch: true` 及基础超时值）。
+- **Settings hot-reload per the docs** — `apply` now registers the config through `ctx.settings.installSection` (namespace `dsh-tinyfish-search`), exactly like `web-search-deepseek`: the Plugins settings card renders the section, and a saved edit (e.g. a new `apiKeyEnv` or `baseURL`) reaches the next search without a restart. Removed the dead no-op settings probe and its misleading comment. / **按文档接入设置热更新** —— `apply` 现通过 `ctx.settings.installSection` 注册配置（命名空间 `dsh-tinyfish-search`），与 `web-search-deepseek` 完全一致：Plugins 设置卡片可渲染该节，保存的修改（如新的 `apiKeyEnv` 或 `baseURL`）无需重启即对下一次搜索生效。同时删除了无操作死代码及其误导性注释。
+
 ## [0.1.8] - 2026-09-03
 
 ### English

--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ Installing the bundle **takes over the built-in `web_search` automatically**: th
 bundle patch overrides the `web` seam row (`searchProvider: tinyfish`,
 `fetchProvider: http` restated), because `dsh-base` pins the seam to
 `deepseek-official` and would otherwise keep the tool on the DeepSeek backend.
-Later layers (profile / home `cordis.patch.yml` / `--patch`) can still
-override that row, and `available()` still requires a TinyFish API key.
+It also **re-enables the `tool-web` row** (`search: true`, `fetch: true` and the
+base timeouts restated) — the `dsh-web-app` bundle ships `tool-web` disabled,
+and without that row the model would see no `web_search` tool at all (fixed in
+0.1.9; earlier releases needed a manual profile-patch override). Later layers
+(profile / home `cordis.patch.yml` / `--patch`) can still override those rows,
+and `available()` still requires a TinyFish API key. Configuration is also
+exposed as a `dsh-tinyfish-search` settings section (Plugins settings page):
+a saved edit reaches the next search without a restart.
 
 ### Requirements
 
@@ -149,7 +155,7 @@ DeepSeek Harness 内置的 `web_search` 工具默认走 DeepSeek 的 Anthropic �
 - 把 `results[]`（标题 / 摘要 / 链接 / 日期）归一化为缝接口的可移植来源结构
 - **每次搜索不消耗一次模型调用**——与 Anthropic 服务器工具方案不同，更快更省
 
-安装本插件后，内置 `web_search` 会被**自动接管**：bundle patch 会覆盖 `web` 能力缝行（`searchProvider: tinyfish`，并重述 `fetchProvider: http`）——因为 `dsh-base` 把该行钉死为 `deepseek-official`，否则插件即使注册了 provider，工具仍会走 DeepSeek 后端。更后层（profile / home `cordis.patch.yml` / `--patch`）仍可按 id 覆盖该行；并且 `available()` 仍要求配置 TinyFish API key。
+安装本插件后，内置 `web_search` 会被**自动接管**：bundle patch 会覆盖 `web` 能力缝行（`searchProvider: tinyfish`，并重述 `fetchProvider: http`）——因为 `dsh-base` 把该行钉死为 `deepseek-official`，否则插件即使注册了 provider，工具仍会走 DeepSeek 后端。同时补丁还会**重新启用 `tool-web` 行**（重述 `search: true`、`fetch: true` 及基础超时值）——`dsh-web-app` bundle 自带 `tool-web` 禁用行，缺了这一行模型根本看不到 `web_search` 工具（0.1.9 修复；更早版本需要在 profile 补丁里手工覆盖）。更后层（profile / home `cordis.patch.yml` / `--patch`）仍可按 id 覆盖这些行；并且 `available()` 仍要求配置 TinyFish API key。配置同时以 `dsh-tinyfish-search` 设置节暴露（Plugins 设置页）：保存的修改无需重启即对下一次搜索生效。
 
 ### 环境要求
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,18 +1,28 @@
 # dsh-tinyfish-search bundle layer.
 #
-# 1. Insert the plugin row. The row references the package by name so Node
-#    resolution finds the installed code (npm, tarball, or git install). Its
-#    `config` mapping is the documented scaffolding: every field is optional
-#    and commented out, so the shipped defaults apply until a later layer
-#    (profile / home cordis.patch.yml / --patch) overrides this row by id.
-# 2. Route the web capability seam to this plugin's provider. The dsh-base
-#    bundle pins `searchProvider: deepseek-official` on the `web` row, so
-#    merely registering a provider would leave web_search on the DeepSeek
-#    backend even with this bundle installed. Per the layer rules a bundle
-#    patch may override an earlier row by id, restating every key the row
-#    needs (config is replaced wholesale, never deep-merged). Later layers
-#    (profile / home cordis.patch.yml / --patch overlays) can still override
-#    this row by id, as usual.
+# Three rows:
+#  1. `dsh-tinyfish-search` — this plugin: registers the `tinyfish` search
+#     provider on the ctx.web seam. The row references the package by name so
+#     Node resolution finds the installed code (npm, tarball, or git install).
+#     Its `config` mapping is the documented scaffolding: every field is
+#     optional and commented out, so the shipped defaults apply until a later
+#     layer (profile / home cordis.patch.yml / --patch) overrides this row by id.
+#  2. `web` — points ctx.web at this provider. The dsh-base bundle pins
+#     `searchProvider: deepseek-official` on the `web` row, so merely
+#     registering a provider would leave web_search on the DeepSeek backend
+#     even with this bundle installed. Per the layer rules a bundle patch may
+#     override an earlier row by id, restating every key the row needs (config
+#     is replaced wholesale, never deep-merged). Later layers (profile / home
+#     cordis.patch.yml / --patch overlays) can still override this row by id.
+#  3. `tool-web` — re-enables the model-facing web tools. The dsh-web-app
+#     bundle ships `tool-web` disabled (and `fetch: true` is a dsh-base key
+#     already restated here); without this row the model never sees
+#     `web_search` at all, leaving the TinyFish provider idle. Restates every
+#     dsh-base key for the same replace-wholesale reason as above.
+#
+# Users can override any of these in their profile's cordis.patch.yml — the
+# user layer applies after bundle layers ("last write wins per row").
+
 - insert:
     - id: dsh-tinyfish-search
       name: dsh-tinyfish-search
@@ -24,3 +34,9 @@
   config:
     searchProvider: tinyfish
     fetchProvider: http
+- id: tool-web
+  config:
+    search: true
+    fetch: true
+    searchTimeoutMs: 60000
+    fetchTimeoutMs: 30000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tinyfish-search",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TinyFish-backed web search provider for DeepSeek Harness (ctx.web): makes the built-in web_search tool run on the TinyFish Search API — 将内置 web_search 接入 TinyFish Search API 的 DeepSeek Harness 插件",
   "type": "module",
   "main": "lib/index.js",
@@ -55,19 +55,24 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.0 <5.0.0",
-    "@deepseek-ai/dsh-web": ">=0.1.2-alpha.2 <0.2.0",
     "@deepseek-ai/dsh-credentials": "*",
-    "@deepseek-ai/dsh-launch-environment": "*"
+    "@deepseek-ai/dsh-launch-environment": "*",
+    "@deepseek-ai/dsh-web": ">=0.1.2-alpha.2 <0.2.0"
   },
   "peerDependenciesMeta": {
-    "@deepseek-ai/dsh-credentials": { "optional": true },
-    "@deepseek-ai/dsh-launch-environment": { "optional": true }
+    "@deepseek-ai/dsh-credentials": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-launch-environment": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.2",
     "@deepseek-ai/dsh-credentials": "0.1.2-rc.1",
     "@deepseek-ai/dsh-launch-environment": "0.1.2-rc.1",
     "@deepseek-ai/dsh-llm": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-settings": "0.1.2-rc.1",
     "@deepseek-ai/dsh-web": "0.1.2-rc.1",
     "typescript": "5.8.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@deepseek-ai/dsh-llm':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-settings':
+        specifier: 0.1.2-rc.1
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))))(@deepseek-ai/schemastery@3.18.2)
       '@deepseek-ai/dsh-web':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
@@ -76,6 +79,27 @@ packages:
     resolution: {integrity: sha512-7VYsha5AXsVLnsAwYJffWXz9bwUbElw8i5N8tlTSdai9Bupk3sMbsotzPf8ZbsuGAxQYErahMwQwgGEu4qZO6g==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
+
+  '@deepseek-ai/dsh-scope@0.1.2-rc.1':
+    resolution: {integrity: sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
+
+  '@deepseek-ai/dsh-session@0.1.2-rc.1':
+    resolution: {integrity: sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-scope': ^0.1.2-rc.1
+
+  '@deepseek-ai/dsh-settings@0.1.2-rc.1':
+    resolution: {integrity: sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-brand': ^0.1.2-rc.1
+      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
+      '@deepseek-ai/dsh-session': ^0.1.2-rc.1
+      '@deepseek-ai/schemastery': ^3.18.2
 
   '@deepseek-ai/dsh-timeout@0.1.2-rc.1':
     resolution: {integrity: sha512-llz11yxWeJB8suKCa6hRLjNBWVaPn3Fbd0XoBS0bkZLhPFzO1mDorx/XMca2GhI7XF9A86CURQcDt+aGjjvqJA==}
@@ -155,6 +179,28 @@ snapshots:
       '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/schemastery': 3.18.2
       zod: 4.5.4
+
+  '@deepseek-ai/dsh-scope@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+      '@deepseek-ai/dsh-invariants': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+
+  '@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-scope': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+
+  '@deepseek-ai/dsh-settings@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))))(@deepseek-ai/schemastery@3.18.2)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-session': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))
+      '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/schemastery': 3.18.2
 
   '@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,9 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/schemastery@3.18.2'
   - '@deepseek-ai/dsh-credentials@0.1.2-alpha.4 || 0.1.2-alpha.5 || 0.1.2-rc.1'
   - '@deepseek-ai/dsh-launch-environment@0.1.2-alpha.4 || 0.1.2-alpha.5 || 0.1.2-rc.1'
+  - '@deepseek-ai/dsh-scope@0.1.2-rc.1'
+  - '@deepseek-ai/dsh-session@0.1.2-rc.1'
+  - '@deepseek-ai/dsh-settings@0.1.2-rc.1'
 # pnpm 11 workspace config for dsh-tinyfish-search.
 # Supply-chain policy on this machine rejects packages published within the
 # last day (minimumReleaseAge), so transitive versions are pinned to

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
 import { credentialRef } from '@deepseek-ai/dsh-credentials'
 import { launchEnvironmentOf } from '@deepseek-ai/dsh-launch-environment'
+// Type-only: pulls the ctx.settings merge (SettingsProvider) into this program.
+import type {} from '@deepseek-ai/dsh-settings'
 import {
   WebError,
 } from '@deepseek-ai/dsh-web'
@@ -30,6 +32,9 @@ import type {
 
 /** Stable provider id this plugin registers under. */
 export const TINYFISH_PROVIDER_ID = 'tinyfish'
+
+/** Settings namespace for the configuration card / user document. */
+export const TINYFISH_SETTINGS_NAMESPACE = 'dsh-tinyfish-search'
 
 /**
  * Minimal module-scoped `process` reference (only `process.env` is used). The
@@ -45,7 +50,7 @@ export const TINYFISH_DEFAULT_BASE_URL = 'https://api.search.tinyfish.ai'
 export const DEFAULT_API_KEY_ENV = 'TINYFISH_API_KEY'
 
 /** Attribution header sent on every request. Bump with the package version. */
-const USER_AGENT = 'dsh-tinyfish-search/0.1.8'
+const USER_AGENT = 'dsh-tinyfish-search/0.1.9'
 
 /** Cordis plugin name used by loader diagnostics and the bundle patch row. */
 export const name = 'dsh-tinyfish-search'
@@ -102,13 +107,20 @@ function resolveOptions(ctx: Context, config: Config): TinyFishOptions {
 /** Register the TinyFish search provider with `ctx.web`. */
 export function apply(ctx: Context, config: Config): void {
   let current: () => Config = () => config
-  // Keep config hot-reloadable via settings if the host provides it
-  try {
-    const maybeSettings: any = (ctx as any).get?.('settings')
-    if (maybeSettings !== undefined) {
-      // No-op if settings service is not available in this profile
-    }
-  } catch {}
+  // Settings hot-reload, mirroring dsh-web-search-deepseek: the section layers
+  // the composition entry under the user document when a settings provider is
+  // mounted, and re-resolves per search (resolveOptions reads `current()`), so
+  // a committed settings edit reaches the next search without a restart.
+  ctx.inject(['settings'], (settingsCtx) => {
+    settingsCtx.settings.installSection(ctx, TINYFISH_SETTINGS_NAMESPACE, Config, config, {
+      setSource: (source) => {
+        current = source
+      },
+      // The registration carries no resolved value: the provider resolves the
+      // credential per search, so a committed change needs no re-registration.
+      onChange: () => {},
+    })
+  })
   ctx.web.registerSearchProvider(new TinyFishSearchProvider(() => resolveOptions(ctx, current())))
 }
 


### PR DESCRIPTION
## English

**Fixed / 修复**

- **Fix: the bundle patch now re-enables `tool-web` — without it `web_search` was never registered.** The `@deepseek-ai/dsh-web-app` bundle ships the `tool-web` row **disabled**; dsh-base enables it only in headless/server profiles. The searxng-web bundle re-enables the row in its own patch, but the dsh-tinyfish-search patch did not, so on a clean install into a web profile the model saw no `web_search` tool at all and the TinyFish provider sat idle. The patch now restates the row with `search: true`, `fetch: true`, and the base timeouts, mirroring searxng-web.
- **Settings hot-reload per the plugin docs** — `apply` now registers the config through `ctx.settings.installSection` (namespace `dsh-tinyfish-search`), exactly like `web-search-deepseek`: the Plugins settings card renders the section, and a saved edit (e.g. a new `apiKeyEnv` or `baseURL`) reaches the next search without a restart. Removed the dead no-op settings probe and its misleading comment.
- Update: `dsh plugin update dsh-tinyfish-search` (or `dsh plugin add dsh-tinyfish-search@0.1.9`).
- Requirements: harness `0.1.2-rc.1`, a TinyFish API key (`TINYFISH_API_KEY` env, `dsh credentials set`, or `apiKey` config).
- Install: `dsh plugin add dsh-tinyfish-search` — the bundle patch registers the provider row, routes `searchProvider: tinyfish`, and re-enables `tool-web`.
- Uninstall: `dsh plugin remove dsh-tinyfish-search` (the `web` / `tool-web` rows revert to the bundles' own layers).
- Usage: after install, the built-in `web_search` tool runs on the TinyFish Search API automatically.
- Config: `apiKey` (literal, wins over env), `apiKeyEnv` (default `TINYFISH_API_KEY`, credential-ref), `baseURL` (default `https://api.search.tinyfish.ai`).

## 中文

**修复说明**

- **修复：bundle 补丁现重新启用 `tool-web` —— 缺失时 `web_search` 根本不会注册。** `@deepseek-ai/dsh-web-app` bundle 自带 `tool-web` **禁用**行（dsh-base 仅在 headless/server 组合中启用它）。searxng-web 的补丁自己重新启用了该行，而 dsh-tinyfish-search 的补丁没有 —— 干净安装到 web profile 后模型看不到 `web_search` 工具，TinyFish 提供方完全闲置。现按 searxng-web 的方式补上该行（`search: true`、`fetch: true` 及基础超时值）。
- **按文档接入设置热更新** —— `apply` 现通过 `ctx.settings.installSection` 注册配置（命名空间 `dsh-tinyfish-search`），与 `web-search-deepseek` 完全一致：Plugins 设置卡片可渲染该节，保存的修改（如新的 `apiKeyEnv` 或 `baseURL`）无需重启即对下一次搜索生效。同时删除了无操作死代码及其误导性注释。
- 升级：`dsh plugin update dsh-tinyfish-search`（或 `dsh plugin add dsh-tinyfish-search@0.1.9`）。
- 环境要求：harness `0.1.2-rc.1`，一个 TinyFish API key（`TINYFISH_API_KEY` 环境变量、`dsh credentials set` 或 `apiKey` 配置均可）。
- 安装：`dsh plugin add dsh-tinyfish-search` —— bundle 补丁注册 provider 行、把 `searchProvider` 指向 `tinyfish`，并重新启用 `tool-web`。
- 卸载：`dsh plugin remove dsh-tinyfish-search`（`web` / `tool-web` 行自动回落到各 bundle 自身层级）。
- 使用：安装后内置 `web_search` 工具自动走 TinyFish Search API。
- 配置：`apiKey`（字面密钥，优先于环境变量）、`apiKeyEnv`（默认 `TINYFISH_API_KEY`，credential-ref 类型）、`baseURL`（默认 `https://api.search.tinyfish.ai`）。

## Verification / 验证

- Tests 9/9 pass. / 测试 9/9 通过。
- Verified on harness `0.1.2-rc.1`: composed `web` row points at `tinyfish`, `tool-web` enabled, model-facing `web_search` registered. / 已在 harness `0.1.2-rc.1` 上验证组合结果。
