### PR TITLE
release: v0.2.0 — tool-web row clears disabled explicitly (disabled: false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here / 本项目的所有重要变更均记录于此。
 The format follows [Keep a Changelog](https://keepachangelog.com/) / 格式遵循 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [0.2.0] - 2026-09-03
+
+### Fixed / 修复
+
+- **Fix: the `tool-web` re-enable row now clears `disabled` explicitly (`disabled: false`).** The loader's id-patch merge is **per-key**: a config-only row restates `config` but leaves the `disabled: true` shipped by the `@deepseek-ai/dsh-web-app` bundle in place, so 0.1.9's re-enable row still left `web_search` unregistered. Verified with `dsh --profile web --dump-config`: the composed `tool-web` row now carries `disabled: false` and the model-facing `web_search` / `web_fetch` tools mount. / **修复：`tool-web` 重启用行现在显式清除 `disabled`（`disabled: false`）。** loader 的按 id 补丁合并是**按键生效**的：仅带 `config` 的行会重述配置但保留 `@deepseek-ai/dsh-web-app` bundle 自带的 `disabled: true`，因此 0.1.9 的重启用行依然让 `web_search` 处于未注册状态。已用 `dsh --profile web --dump-config` 验证：组合后的 `tool-web` 行现为 `disabled: false`，模型可见的 `web_search` / `web_fetch` 工具正常挂载。
+
 ## [0.1.9] - 2026-09-03
 
 ### Fixed / 修复

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -35,6 +35,10 @@
     searchProvider: tinyfish
     fetchProvider: http
 - id: tool-web
+  # `disabled: false` is REQUIRED: the merge is per-key, so a config-only row
+  # would leave the `disabled: true` shipped by the dsh-web-app bundle in place
+  # and web_search would never register.
+  disabled: false
   config:
     search: true
     fetch: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tinyfish-search",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "TinyFish-backed web search provider for DeepSeek Harness (ctx.web): makes the built-in web_search tool run on the TinyFish Search API — 将内置 web_search 接入 TinyFish Search API 的 DeepSeek Harness 插件",
   "type": "module",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export const TINYFISH_DEFAULT_BASE_URL = 'https://api.search.tinyfish.ai'
 export const DEFAULT_API_KEY_ENV = 'TINYFISH_API_KEY'
 
 /** Attribution header sent on every request. Bump with the package version. */
-const USER_AGENT = 'dsh-tinyfish-search/0.1.9'
+const USER_AGENT = 'dsh-tinyfish-search/0.2.0'
 
 /** Cordis plugin name used by loader diagnostics and the bundle patch row. */
 export const name = 'dsh-tinyfish-search'


### PR DESCRIPTION
## English

**Fixed / 修复**

- **Fix: the `tool-web` re-enable row now clears `disabled` explicitly (`disabled: false`).** The loader's id-patch merge is **per-key**: a config-only row restates `config` but leaves the `disabled: true` shipped by the `@deepseek-ai/dsh-web-app` bundle in place, so 0.1.9's re-enable row still left `web_search` unregistered. Verified with `dsh --profile web --dump-config`: the composed `tool-web` row now carries `disabled: false` and the model-facing `web_search` / `web_fetch` tools mount.
- Update: `dsh plugin update dsh-tinyfish-search` (or `dsh plugin add dsh-tinyfish-search@0.2.0`).
- Requirements: harness `0.1.2-rc.1`, a TinyFish API key (`TINYFISH_API_KEY` env, `dsh credentials set`, or `apiKey` config).
- Install: `dsh plugin add dsh-tinyfish-search` — the bundle patch registers the provider row, routes `searchProvider: tinyfish`, and re-enables `tool-web` (now with `disabled: false`).
- Uninstall: `dsh plugin remove dsh-tinyfish-search`.
- Usage: after install, the built-in `web_search` tool runs on the TinyFish Search API automatically; config edits in the Plugins settings card reach the next search without a restart.
- Config: `apiKey` (literal, wins over env), `apiKeyEnv` (default `TINYFISH_API_KEY`, credential-ref), `baseURL` (default `https://api.search.tinyfish.ai`).

## 中文

**修复说明**

- **修复：`tool-web` 重启用行现在显式清除 `disabled`（`disabled: false`）。** loader 的按 id 补丁合并是**按键生效**的：仅带 `config` 的行会重述配置但保留 `@deepseek-ai/dsh-web-app` bundle 自带的 `disabled: true`，因此 0.1.9 的重启用行依然让 `web_search` 处于未注册状态。已用 `dsh --profile web --dump-config` 验证：组合后的 `tool-web` 行现为 `disabled: false`，模型可见的 `web_search` / `web_fetch` 工具正常挂载。
- 升级：`dsh plugin update dsh-tinyfish-search`（或 `dsh plugin add dsh-tinyfish-search@0.2.0`）。
- 环境要求：harness `0.1.2-rc.1`，一个 TinyFish API key（`TINYFISH_API_KEY` 环境变量、`dsh credentials set` 或 `apiKey` 配置均可）。
- 安装：`dsh plugin add dsh-tinyfish-search` —— bundle 补丁注册 provider 行、把 `searchProvider` 指向 `tinyfish`，并重新启用 `tool-web`（现已带 `disabled: false`）。
- 卸载：`dsh plugin remove dsh-tinyfish-search`。
- 使用：安装后内置 `web_search` 工具自动走 TinyFish Search API；在 Plugins 设置卡片修改配置后无需重启即对下一次搜索生效。
- 配置：`apiKey`（字面密钥，优先于环境变量）、`apiKeyEnv`（默认 `TINYFISH_API_KEY`，credential-ref 类型）、`baseURL`（默认 `https://api.search.tinyfish.ai`）。
