### PR TITLE
release: v0.2.1 — adapt to deepseek-harness 0.1.3-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project are documented here / 本项目的所有重要变更均记录于此。
 The format follows [Keep a Changelog](https://keepachangelog.com/) / 格式遵循 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [0.2.1] - 2026-09-04
+
+### English
+
+**Compatibility / 兼容性**
+
+- Verified against deepseek-harness `0.1.3-alpha.1` (latest release): no seam changes since `0.1.2-rc.1` — the web seam (`WebSearchProvider` / `WebSearchRequest` / `WebSearchResult` / `WebSearchSource` / `WebError`), the credentials seam, the launch-environment seam, and the settings section install (`ctx.settings.installSection`) are all source-identical between the two tags, as are the vendored `@deepseek-ai/cordis` `4.0.2` and the loader / bundle patch mechanism. 0.1.3's headline changes (environment-proxy support, Session persistence rework, file attachments) do not touch any seam this plugin consumes. The published `@deepseek-ai/dsh-*` type packages remain at `0.1.2-rc.1` (the newest release on npm); because the seam sources are unchanged, type-checking against them is equivalent to checking against `0.1.3-alpha.1` sources. `USER_AGENT` bumped to `dsh-tinyfish-search/0.2.1`. The full test suite passes.
+
+### 中文
+
+**兼容性 / Compatibility**
+
+- 已针对 deepseek-harness `0.1.3-alpha.1`（最新发行版）验证：自 `0.1.2-rc.1` 以来缝接口无任何变更 —— web 缝（`WebSearchProvider` / `WebSearchRequest` / `WebSearchResult` / `WebSearchSource` / `WebError`）、凭据缝、启动环境缝以及设置节安装（`ctx.settings.installSection`）在两个 tag 之间源码完全一致，内置 `@deepseek-ai/cordis` `4.0.2` 与 loader / bundle 补丁机制亦未变化。0.1.3 的主要变更（环境代理支持、Session 持久化重构、文件附件）均不涉及本插件消费的任何缝。npm 上已发布的 `@deepseek-ai/dsh-*` 类型包仍为 `0.1.2-rc.1`（npm 上的最新版本）；由于缝源码未变，针对它们做类型检查与针对 `0.1.3-alpha.1` 源码等价。`USER_AGENT` 升至 `dsh-tinyfish-search/0.2.1`。全部测试通过。
+
 ## [0.2.0] - 2026-09-03
 
 ### Fixed / 修复

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ a saved edit reaches the next search without a restart.
 
 ### Requirements
 
-- DeepSeek Harness `dsh` CLI (any profile with the web seam, e.g. `web`) — verified on `0.1.2-rc.1` (latest `master`; `0.1.2-alpha.5` → `0.1.2-rc.1` no seam changes)
+- DeepSeek Harness `dsh` CLI (any profile with the web seam, e.g. `web`) — verified on `0.1.3-alpha.1` (latest release; `0.1.2-rc.1` → `0.1.3-alpha.1` no seam changes)
 - A [TinyFish API key](https://agent.tinyfish.ai/api-keys) (free to create; Search is free)
 
 ### Install
@@ -159,7 +159,7 @@ DeepSeek Harness 内置的 `web_search` 工具默认走 DeepSeek 的 Anthropic �
 
 ### 环境要求
 
-- DeepSeek Harness `dsh` CLI（任意带 web 缝的 profile，如 `web`）——已验证 `0.1.2-rc.1`（最新 `master`；`0.1.2-alpha.5` → `0.1.2-rc.1` 缝接口无变更）
+- DeepSeek Harness `dsh` CLI（任意带 web 缝的 profile，如 `web`）——已验证 `0.1.3-alpha.1`（最新发行版；`0.1.2-rc.1` → `0.1.3-alpha.1` 缝接口无变更）
 - 一个 [TinyFish API key](https://agent.tinyfish.ai/api-keys)（免费创建；Search 免费）
 
 ### 安装

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tinyfish-search",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TinyFish-backed web search provider for DeepSeek Harness (ctx.web): makes the built-in web_search tool run on the TinyFish Search API — 将内置 web_search 接入 TinyFish Search API 的 DeepSeek Harness 插件",
   "type": "module",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export const TINYFISH_DEFAULT_BASE_URL = 'https://api.search.tinyfish.ai'
 export const DEFAULT_API_KEY_ENV = 'TINYFISH_API_KEY'
 
 /** Attribution header sent on every request. Bump with the package version. */
-const USER_AGENT = 'dsh-tinyfish-search/0.2.0'
+const USER_AGENT = 'dsh-tinyfish-search/0.2.1'
 
 /** Cordis plugin name used by loader diagnostics and the bundle patch row. */
 export const name = 'dsh-tinyfish-search'


### PR DESCRIPTION
Verified no seam changes between dsh-v0.1.2-rc.1 and dsh-v0.1.3-alpha.1 (web/credentials/launch-environment/settings seams, cordis 4.0.2, loader/bundle patch mechanism all source-identical). dsh-* npm type packages stay at 0.1.2-rc.1 (0.1.3-alpha.1 not yet on npm). USER_AGENT bumped; README (EN/ZH) + CHANGELOG updated. Tests 9/9 pass.