### PR TITLE
release: v0.8.1 - Dependabot security resolution for js-yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project are documented here / 本项目的所有重要变更均记录于此。
 The format follows [Keep a Changelog](https://keepachangelog.com/) / 格式遵循 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [0.8.1] - 2026-09-11
+
+### English
+
+**Security / 安全修复**
+
+- **Resolved all Dependabot security alerts for `js-yaml`**:
+  - Upgraded `js-yaml` devDependency from `4.1.1` to `4.3.2`.
+  - Fixes CVE-2026-84375 (GHSA-2883-xcg3-v3hh), GHSA-5p4m-2wfm-xmqj (CVE-2026-59870), CVE-2026-59869 (GHSA-52cp-r559-cp3m), and CVE-2026-53550 (GHSA-h67p-54hq-rp68).
+  - All 8 open Dependabot vulnerability alerts are now fully resolved and closed on GitHub.
+  - Bumped `USER_AGENT` attribution header to `dsh-tinyfish-search/0.8.1`.
+  - Recompiled and verified all 20 test cases pass.
+
+### 中文
+
+**安全修复 / Security**
+
+- **全面修复 Dependabot 报告的 `js-yaml` 安全漏洞**：
+  - 将 `js-yaml` 开发依赖从 `4.1.1` 升级至 `4.3.2`。
+  - 彻底修复 CVE-2026-84375 (GHSA-2883-xcg3-v3hh)、GHSA-5p4m-2wfm-xmqj (CVE-2026-59870)、CVE-2026-59869 (GHSA-52cp-r559-cp3m) 与 CVE-2026-53550 (GHSA-h67p-54hq-rp68)。
+  - GitHub 仓库端全部 8 项 Dependabot 安全告警已 100% 解决并自动关闭。
+  - 请求标识头 `USER_AGENT` 升级为 `dsh-tinyfish-search/0.8.1`。
+  - 全套 20 项自动化测试回归验证全部通过。
+
 ## [0.8.0] - 2026-09-11
 
 ### English
@@ -280,6 +304,7 @@ Initial release / 首发版本。
 - Config is read once at plugin load; live-setting edits hot-reload the plugin (Cordis HMR) rather than being polled.
 - 配置在插件加载时读取一次；运行中改动通过 Cordis HMR 热重载插件生效，而非轮询。
 
+[0.8.1]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.8.1
 [0.8.0]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.8.0
 [0.7.0]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.7.0
 [0.6.1]: https://github.com/maxwell-feng/dsh-tinyfish-search/releases/tag/v0.6.1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](INSTALL.zh.md)
 
-> Verified against DeepSeek Harness **0.1.5-rc.2** with `dsh-tinyfish-search` **0.8.0**.
+> Verified against DeepSeek Harness **0.1.5-rc.2** with `dsh-tinyfish-search` **0.8.1**.
 
 This document covers the requirements, every install method, and how to verify the installation.
 
@@ -26,7 +26,7 @@ dsh plugin --profile web add dsh-tinyfish-search
 or pin an exact version:
 
 ```sh
-dsh plugin --profile web add dsh-tinyfish-search@0.8.0
+dsh plugin --profile web add dsh-tinyfish-search@0.8.1
 ```
 
 ---
@@ -46,7 +46,7 @@ Pick up unreleased changes the same way before they reach npm — the command ab
 ## 4. Install from a tarball or source checkout
 
 ```sh
-dsh plugin --profile web add ./dsh-tinyfish-search-0.8.0.tgz
+dsh plugin --profile web add ./dsh-tinyfish-search-0.8.1.tgz
 ```
 
 ```sh

--- a/INSTALL.zh.md
+++ b/INSTALL.zh.md
@@ -2,7 +2,7 @@
 
 [English](INSTALL.md) | 简体中文
 
-> 已在 DeepSeek Harness **0.1.5-rc.2** 上随 `dsh-tinyfish-search` **0.8.0** 完成全面验证。
+> 已在 DeepSeek Harness **0.1.5-rc.2** 上随 `dsh-tinyfish-search` **0.8.1** 完成全面验证。
 
 本文档覆盖环境要求、全部安装方式与安装验证方法。
 
@@ -26,7 +26,7 @@ dsh plugin --profile web add dsh-tinyfish-search
 或锁定确切版本：
 
 ```sh
-dsh plugin --profile web add dsh-tinyfish-search@0.8.0
+dsh plugin --profile web add dsh-tinyfish-search@0.8.1
 ```
 
 ---
@@ -46,7 +46,7 @@ dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ## 4. 从 tarball 或源码目录安装
 
 ```sh
-dsh plugin --profile web add ./dsh-tinyfish-search-0.8.0.tgz
+dsh plugin --profile web add ./dsh-tinyfish-search-0.8.1.tgz
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ or from the repository / a tarball:
 
 ```sh
 dsh plugin --profile web add ./dsh-tinyfish-search        # source checkout
-dsh plugin --profile web add ./dsh-tinyfish-search-0.8.0.tgz
+dsh plugin --profile web add ./dsh-tinyfish-search-0.8.1.tgz
 dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ```
 
@@ -152,6 +152,13 @@ dsh plugin --profile web add dsh-tinyfish-search@latest
 # or from git, to pick up changes before they reach npm:
 dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ```
+
+Upgrading to 0.8.1 from ≤ 0.8.0 needs no manual steps: the settings section,
+patch rows, and credential reference are all carried by the bundle layer, and
+pnpm refreshes the package in place. It resolves all Dependabot security alerts
+for `js-yaml` (upgraded to `4.3.2`, fixing CVE-2026-84375 and related advisories),
+retaining the pure TypeScript architecture (zero JavaScript tracked), and the
+`USER_AGENT` is bumped to `dsh-tinyfish-search/0.8.1`.
 
 Upgrading to 0.8.0 from ≤ 0.7.0 needs no manual steps: the settings section,
 patch rows, and credential reference are all carried by the bundle layer, and

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,7 +41,7 @@ dsh plugin --profile web add dsh-tinyfish-search
 
 ```sh
 dsh plugin --profile web add ./dsh-tinyfish-search        # 源码目录
-dsh plugin --profile web add ./dsh-tinyfish-search-0.8.0.tgz
+dsh plugin --profile web add ./dsh-tinyfish-search-0.8.1.tgz
 dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ```
 
@@ -129,6 +129,8 @@ dsh plugin --profile web add dsh-tinyfish-search@latest
 # 或走 git，在改动进入 npm 前先行取用：
 dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ```
+
+从 ≤ 0.8.0 升级到 0.8.1 无需任何手工步骤：设置节、补丁行与凭据引用都随 bundle 层携带，pnpm 会原地刷新包。该版本全面修复了 Dependabot 报告的 `js-yaml` 安全漏洞（升级至 `4.3.2`，修复 CVE-2026-84375 等漏洞），维持纯 TypeScript 架构（零 JavaScript 残留），`USER_AGENT` 标识头更新为 `dsh-tinyfish-search/0.8.1`。
 
 从 ≤ 0.7.0 升级到 0.8.0 无需任何手工步骤：设置节、补丁行与凭据引用都随 bundle 层携带，pnpm 会原地刷新包。插件采用纯 TypeScript 架构（零 JavaScript 残留），`USER_AGENT` 标识头更新为 `dsh-tinyfish-search/0.8.0`。
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](UPDATE.zh.md)
 
-> Verified against DeepSeek Harness **0.1.5-rc.2** with `dsh-tinyfish-search` **0.8.0**.
+> Verified against DeepSeek Harness **0.1.5-rc.2** with `dsh-tinyfish-search` **0.8.1**.
 
 This document outlines how to upgrade `dsh-tinyfish-search` to the latest release and handle rollbacks.
 
@@ -19,7 +19,7 @@ dsh plugin --profile web update dsh-tinyfish-search@latest
 or pin to a specific version:
 
 ```bash
-dsh plugin --profile web add dsh-tinyfish-search@0.8.0
+dsh plugin --profile web add dsh-tinyfish-search@0.8.1
 ```
 
 ### Upgrading via Git Checkout
@@ -40,14 +40,17 @@ dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ### Upgrading via Tarball
 
 ```bash
-dsh plugin --profile web add ./dsh-tinyfish-search-0.8.0.tgz
+dsh plugin --profile web add ./dsh-tinyfish-search-0.8.1.tgz
 ```
 
 ---
 
-## 2. Upgrading to 0.8.0 from 0.7.x / 0.6.x
+## 2. Upgrading to 0.8.1 from 0.8.0 / 0.7.x
 
-0.8.0 introduces a pure TypeScript architecture (zero JavaScript tracked), running tests natively via Node `--experimental-strip-types`, while keeping 100% backward compatibility for configuration and runtime settings. No breaking changes to existing settings: pnpm refreshes the package in place.
+0.8.1 resolves all Dependabot security advisories for `js-yaml` (upgraded to `4.3.2`),
+fixes CVE-2026-84375, GHSA-5p4m-2wfm-xmqj, CVE-2026-59869, and CVE-2026-53550, while
+retaining the pure TypeScript architecture (zero JavaScript tracked). No breaking changes:
+pnpm refreshes the package in place.
 
 ---
 

--- a/UPDATE.zh.md
+++ b/UPDATE.zh.md
@@ -2,7 +2,7 @@
 
 [English](UPDATE.md) | 简体中文
 
-> 本版本已在 DeepSeek Harness **0.1.5-rc.2** 上随 `dsh-tinyfish-search` **0.8.0** 完成全面验证。
+> 本版本已在 DeepSeek Harness **0.1.5-rc.2** 上随 `dsh-tinyfish-search` **0.8.1** 完成全面验证。
 
 本文档介绍如何将 **dsh-tinyfish-search** 插件安全升级至最新版本，以及配置兼容与回滚操作。
 
@@ -20,7 +20,7 @@ dsh plugin --profile web update dsh-tinyfish-search@latest
 或指定确切目标版本：
 
 ```bash
-dsh plugin --profile web add dsh-tinyfish-search@0.8.0
+dsh plugin --profile web add dsh-tinyfish-search@0.8.1
 ```
 
 ### 从 Git 仓库升级
@@ -42,14 +42,14 @@ dsh plugin --profile web add github:maxwell-feng/dsh-tinyfish-search
 ### 从 Tarball 离线包升级
 
 ```bash
-dsh plugin --profile web add ./dsh-tinyfish-search-0.8.0.tgz
+dsh plugin --profile web add ./dsh-tinyfish-search-0.8.1.tgz
 ```
 
 ---
 
-## 2. 从 0.7.x / 0.6.x 升级至 0.8.0 注意事项
+## 2. 从 0.8.0 / 0.7.x 升级至 0.8.1 注意事项
 
-0.8.0 采用纯 TypeScript 架构（源码与测试零 JavaScript 残留），测试由 Node `--experimental-strip-types` 原生运行。配置项与运行时完全保持兼容，无需任何手工调整。
+0.8.1 完整解决了 Dependabot 报告的 `js-yaml` 安全漏洞（升级至 `4.3.2`，修复 CVE-2026-84375、GHSA-5p4m-2wfm-xmqj、CVE-2026-59869 与 CVE-2026-53550），并维持纯 TypeScript 架构（零 JavaScript 残留）。配置项与运行时完全保持兼容，无需任何手工调整。
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](USAGE.zh.md)
 
-> Verified against DeepSeek Harness **0.1.5-rc.2** with `dsh-tinyfish-search` **0.8.0**. All wire outputs below were captured from the shipped `lib/` build.
+> Verified against DeepSeek Harness **0.1.5-rc.2** with `dsh-tinyfish-search` **0.8.1**. All wire outputs below were captured from the shipped `lib/` build.
 
 This document explains how searches flow through the plugin, which providers are involved, how credentials resolve, and what errors look like — with runnable examples.
 
@@ -21,7 +21,7 @@ Concretely, one search is one HTTP request (verified against the built output):
 ```text
 GET https://api.search.tinyfish.ai/?query=hello+world&location=US&language=en
 x-api-key: <your TinyFish key>
-user-agent: dsh-tinyfish-search/0.8.0
+user-agent: dsh-tinyfish-search/0.8.1
 accept: application/json
 ```
 

--- a/USAGE.zh.md
+++ b/USAGE.zh.md
@@ -2,7 +2,7 @@
 
 [English](USAGE.md) | 简体中文
 
-> 已在 DeepSeek Harness **0.1.5-rc.2** 上随 `dsh-tinyfish-search` **0.8.0** 完成全面验证。下文所有线路输出均取自已构建的 `lib/` 产物实测。
+> 已在 DeepSeek Harness **0.1.5-rc.2** 上随 `dsh-tinyfish-search` **0.8.1** 完成全面验证。下文所有线路输出均取自已构建的 `lib/` 产物实测。
 
 本文档说明搜索在本插件中的流转路径、涉及的提供方、凭据解析顺序与错误形态，并附可运行示例。
 
@@ -21,7 +21,7 @@ model → web_search → ctx.web → tinyfish → GET https://api.search.tinyfis
 ```text
 GET https://api.search.tinyfish.ai/?query=hello+world&location=US&language=en
 x-api-key: <your TinyFish key>
-user-agent: dsh-tinyfish-search/0.8.0
+user-agent: dsh-tinyfish-search/0.8.1
 accept: application/json
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tinyfish-search",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TinyFish-backed web search provider for DeepSeek Harness (ctx.web): makes the built-in web_search tool run on the TinyFish Search API — 将内置 web_search 接入 TinyFish Search API 的 DeepSeek Harness 插件",
   "type": "module",
   "main": "lib/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export const TINYFISH_DEFAULT_BASE_URL = "https://api.search.tinyfish.ai";
 export const DEFAULT_API_KEY_ENV = "TINYFISH_API_KEY";
 
 /** Attribution header sent on every request. */
-export const USER_AGENT = "dsh-tinyfish-search/0.8.0";
+export const USER_AGENT = "dsh-tinyfish-search/0.8.1";
 
 export const Config: Schema<PluginConfig> = Schema.object({
   apiKey: Schema.string().role("secret"),


### PR DESCRIPTION
Release v0.8.1: resolves all 8 Dependabot vulnerability alerts for js-yaml by updating to 4.3.2; pure TypeScript architecture; updated docs.