### PR TITLE
docs: restore missing release entry v0.7.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,36 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) / 格式遵�
   - 更新请求标识头 `USER_AGENT` 为 `dsh-tinyfish-search/0.7.0`。
   - 全套 20 项自动化测试验证全部通过。
 
+## [0.7.0] - 2026-09-11
+
+### English
+
+**Changed / 变更**
+
+- **Modular TypeScript Architecture Refactoring / 模块化 TypeScript 架构重构**:
+  - Refactored monolithic codebase into dedicated modules following the official DeepSeek Harness plugin development guide (`docs/cookbook/adding-a-package.md` and `docs/user/develop/basic/index.md`).
+  - Separated public types into `src/types.ts`.
+  - Extracted Schemastery validation into `src/config.ts`.
+  - Extracted multi-tiered credential and environment resolution into `src/options.ts`.
+  - Extracted provider implementation, HTTP wire formatting, and result mapping into `src/provider.ts`.
+  - Exported unified plugin entry from `src/index.ts` with backward-compatible API.
+  - Bumped `USER_AGENT` to `dsh-tinyfish-search/0.7.0`.
+  - Recompiled and verified all 20 test suite cases pass.
+
+### 中文
+
+**变更 / Changed**
+
+- **模块化 TypeScript 架构重构 / Modular TypeScript Architecture Refactoring**：
+  - 严格按照官方 DeepSeek Harness 插件开发规范将单体代码重构为高内聚、模块化 TypeScript 架构。
+  - 将公共类型独立拆分至 `src/types.ts`。
+  - 将 Schemastery 校验逻辑与常量独立拆分至 `src/config.ts`。
+  - 将凭据服务与启动环境多层解析链独立拆分至 `src/options.ts`。
+  - 将 `TinyFishSearchProvider` 核心检索、HTTP 规范映射与结果规整独立拆分至 `src/provider.ts`。
+  - 在 `src/index.ts` 中暴露标准 Cordis 插件入口，并完全保持向下兼容的导出接口。
+  - 更新请求标识头 `USER_AGENT` 为 `dsh-tinyfish-search/0.7.0`。
+  - 重新编译并验证全套 20 项自动化测试全部通过。
+
 ## [0.6.1] - 2026-09-11
 
 ### English


### PR DESCRIPTION
Restore missing v0.7.0 release section in changelog body.